### PR TITLE
Add phpcr-cleanup command

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -15,6 +15,8 @@ services:
         # https://symfony.com/doc/current/service_container.html#binding-arguments-by-name-or-type
         #bind:
         #    'bool $isDebug': '%kernel.debug%'
+        bind:
+            $documentManagerEventDispatcher: '@sulu_document_manager.event_dispatcher.standard'
 
 
     # makes classes in src/ available to be used as services
@@ -28,3 +30,9 @@ services:
 
     # add more service definitions when explicit configuration is needed
     # please note that last definitions always *replace* previous ones
+
+    Sulu\Component\DocumentManager\NamespaceRegistry:
+        alias: sulu_document_manager.namespace_registry
+
+    Sulu\Component\DocumentManager\DocumentManagerInterface:
+        alias: sulu_document_manager.document_manager

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -17,6 +17,7 @@ services:
         #    'bool $isDebug': '%kernel.debug%'
         bind:
             $documentManagerEventDispatcher: '@sulu_document_manager.event_dispatcher.standard'
+            $projectDirectory: '%kernel.project_dir%'
 
 
     # makes classes in src/ available to be used as services

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -18,6 +18,9 @@ services:
         bind:
             $documentManagerEventDispatcher: '@sulu_document_manager.event_dispatcher.standard'
             $projectDirectory: '%kernel.project_dir%'
+            $mapping: '%sulu_document_manager.mapping%'
+            $session: '@sulu_document_manager.default_session'
+            $liveSession: '@sulu_document_manager.live_session'
 
 
     # makes classes in src/ available to be used as services
@@ -37,3 +40,9 @@ services:
 
     Sulu\Component\DocumentManager\DocumentManagerInterface:
         alias: sulu_document_manager.document_manager
+
+    Sulu\Component\Content\Metadata\Factory\StructureMetadataFactoryInterface:
+        alias: sulu_page.structure.factory
+
+    Sulu\Bundle\HttpCacheBundle\EventSubscriber\InvalidationSubscriber:
+        alias: sulu_http_cache.event_subscriber.invalidation

--- a/config/templates/pages/default.xml
+++ b/config/templates/pages/default.xml
@@ -35,12 +35,5 @@
 
             <tag name="sulu.rlp"/>
         </property>
-
-        <property name="article" type="text_editor">
-            <meta>
-                <title lang="en">Article</title>
-                <title lang="de">Artikel</title>
-            </meta>
-        </property>
     </properties>
 </template>

--- a/src/Command/CleanupNode.php
+++ b/src/Command/CleanupNode.php
@@ -1,0 +1,295 @@
+<?php
+
+namespace App\Command;
+
+use PHPCR\ItemInterface;
+use PHPCR\ItemVisitorInterface;
+use PHPCR\NodeInterface;
+use PHPCR\PropertyType;
+
+class CleanupNode implements \IteratorAggregate, NodeInterface
+{
+    private array $writtenProperties = [];
+
+    public function __construct(
+        private NodeInterface $node,
+    ) {
+    }
+
+    public function getWrittenPropertyKeys()
+    {
+        return array_keys($this->writtenProperties);
+    }
+
+    public function getPath()
+    {
+        return $this->node->getPath();
+    }
+
+    public function getName()
+    {
+        return $this->node->getName();
+    }
+
+    public function getAncestor($depth)
+    {
+        return $this->node->getAncestor($depth);
+    }
+
+    public function getParent()
+    {
+        return $this->node->getParent();
+    }
+
+    public function getDepth()
+    {
+        return $this->node->getDepth();
+    }
+
+    public function getSession()
+    {
+        return $this->node->getSession();
+    }
+
+    public function isNode()
+    {
+        return $this->node->isNode();
+    }
+
+    public function isNew()
+    {
+        return $this->node->isNew();
+    }
+
+    public function isModified()
+    {
+        return $this->node->isModified();
+    }
+
+    public function isSame(ItemInterface $otherItem)
+    {
+        return $this->node->isSame($otherItem);
+    }
+
+    public function accept(ItemVisitorInterface $visitor)
+    {
+        $this->node->accept($visitor);
+    }
+
+    public function revert()
+    {
+        $this->node->revert();
+    }
+
+    public function remove()
+    {
+        $this->node->remove();
+    }
+
+    public function addNode($relPath, $primaryNodeTypeName = null)
+    {
+        return $this->node->addNode($relPath, $primaryNodeTypeName);
+    }
+
+    public function addNodeAutoNamed($nameHint = null, $primaryNodeTypeName = null)
+    {
+        return $this->node->addNodeAutoNamed($nameHint, $primaryNodeTypeName);
+    }
+
+    public function orderBefore($srcChildRelPath, $destChildRelPath)
+    {
+        $this->node->orderBefore($srcChildRelPath, $destChildRelPath);
+    }
+
+    public function rename($newName)
+    {
+        $this->node->rename($newName);
+    }
+
+    public function setProperty($name, $value, $type = PropertyType::UNDEFINED)
+    {
+        $this->writtenProperties[$name] = ['value' => $value, 'type' => $type];
+
+        return $this->node->setProperty($name, $value, $type);
+    }
+
+    public function getNode($relPath)
+    {
+        return $this->node->getNode($relPath);
+    }
+
+    public function getNodes($nameFilter = null, $typeFilter = null)
+    {
+        return $this->node->getNodes($nameFilter, $typeFilter);
+    }
+
+    public function getNodeNames($nameFilter = null, $typeFilter = null)
+    {
+        return $this->node->getNodeNames($nameFilter, $typeFilter);
+    }
+
+    public function getProperty($relPath)
+    {
+        return $this->node->getProperty($relPath);
+    }
+
+    public function getPropertyValue($name, $type = PropertyType::UNDEFINED)
+    {
+        return $this->node->getPropertyValue($name, $type);
+    }
+
+    public function getPropertyValueWithDefault($relPath, $defaultValue)
+    {
+        return $this->node->getPropertyValueWithDefault($relPath, $defaultValue);
+    }
+
+    public function getProperties($nameFilter = null)
+    {
+        return $this->node->getProperties($nameFilter);
+    }
+
+    public function getPropertiesValues($nameFilter = null, $dereference = true)
+    {
+        return $this->node->getPropertiesValues($nameFilter, $dereference);
+    }
+
+    public function getPrimaryItem()
+    {
+        return $this->node->getPrimaryItem();
+    }
+
+    public function getIdentifier()
+    {
+        return $this->node->getIdentifier();
+    }
+
+    public function getIndex()
+    {
+        return $this->node->getIndex();
+    }
+
+    public function getReferences($name = null)
+    {
+        return $this->node->getReferences($name);
+    }
+
+    public function getWeakReferences($name = null)
+    {
+        return $this->node->getWeakReferences($name);
+    }
+
+    public function hasNode($relPath)
+    {
+        return $this->node->hasNode($relPath);
+    }
+
+    public function hasProperty($relPath)
+    {
+        return $this->node->hasProperty($relPath);
+    }
+
+    public function hasNodes()
+    {
+        return $this->node->hasNodes();
+    }
+
+    public function hasProperties()
+    {
+        return $this->node->hasProperties();
+    }
+
+    public function getPrimaryNodeType()
+    {
+        return $this->node->getPrimaryNodeType();
+    }
+
+    public function getMixinNodeTypes()
+    {
+        return $this->node->getMixinNodeTypes();
+    }
+
+    public function isNodeType($nodeTypeName)
+    {
+        return $this->node->isNodeType($nodeTypeName);
+    }
+
+    public function setPrimaryType($nodeTypeName)
+    {
+        $this->node->setPrimaryType($nodeTypeName);
+    }
+
+    public function addMixin($mixinName)
+    {
+        $this->node->addMixin($mixinName);
+    }
+
+    public function removeMixin($mixinName)
+    {
+        $this->node->removeMixin($mixinName);
+    }
+
+    public function setMixins(array $mixinNames)
+    {
+        $this->node->setMixins($mixinNames);
+    }
+
+    public function canAddMixin($mixinName)
+    {
+        return $this->node->canAddMixin($mixinName);
+    }
+
+    public function getDefinition()
+    {
+        return $this->node->getDefinition();
+    }
+
+    public function update($srcWorkspace)
+    {
+        $this->node->update($srcWorkspace);
+    }
+
+    public function getCorrespondingNodePath($workspaceName)
+    {
+        return $this->node->getCorrespondingNodePath($workspaceName);
+    }
+
+    public function getSharedSet()
+    {
+        return $this->node->getSharedSet();
+    }
+
+    public function removeSharedSet()
+    {
+        $this->node->removeSharedSet();
+    }
+
+    public function removeShare()
+    {
+        $this->node->removeShare();
+    }
+
+    public function isCheckedOut()
+    {
+        return $this->node->isCheckedOut();
+    }
+
+    public function isLocked()
+    {
+        return $this->node->isLocked();
+    }
+
+    public function followLifecycleTransition($transition)
+    {
+        $this->node->followLifecycleTransition($transition);
+    }
+
+    public function getAllowedLifecycleTransitions()
+    {
+        return $this->node->getAllowedLifecycleTransitions();
+    }
+
+    public function getIterator()
+    {
+        return $this->node->getIterator();
+    }
+}

--- a/src/Command/PHPCRCleanupCommand.php
+++ b/src/Command/PHPCRCleanupCommand.php
@@ -13,7 +13,9 @@ use Sulu\Component\DocumentManager\NamespaceRegistry;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -24,25 +26,129 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class PHPCRCleanupCommand extends Command
 {
     /**
+     * @var string[]
+     */
+    public const WHITELIST = [
+        'state',
+        'created',
+        'creator',
+        'changed',
+        'changer',
+    ];
+
+    /**
      * @var array<string, OptionsResolver> Cached options resolver instances
      */
     private array $optionsResolvers = [];
+
+    /**
+     * @var callable
+     */
+    private $logger;
 
     public function __construct(
         private SessionInterface $session,
         private NamespaceRegistry $namespaceRegistry,
         private EventDispatcherInterface $documentManagerEventDispatcher,
         private DocumentManagerInterface $documentManager,
+        private string $projectDirectory,
     ) {
         parent::__construct();
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function configure()
     {
+        $defaultDebugFile = \sprintf('%s/var/%s_phpcr-cleanup.md', $this->projectDirectory, \date('Y-m-d-H-i-s'));
+
+        $this->addOption('force', 'f', InputOption::VALUE_NONE, 'Do not ask for confirmation.');
+        $this->addOption('dry-run', null, InputOption::VALUE_NONE, 'Do not make any changes to the repository.');
+        $this->addOption('debug', null, InputOption::VALUE_NONE, 'Write debug information to a file.');
+        $this->addOption('debug-file', null, InputOption::VALUE_REQUIRED, 'Write debug information to a file.', $defaultDebugFile);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $io->title('PHPCR Cleanup');
+
+        if (!$input->getOption('dry-run')) {
+            $io->warning('This command will remove properties from the PHPCR repository. Make sure to have a backup before running this command.');
+            if (!$input->getOption('force')) {
+                $answer = $io->ask('Do you want to continue [y/n]', null, function ($value) {
+                    $value = \strtolower($value);
+                    if (!\in_array($value, ['y', 'n'], true)) {
+                        throw new \RuntimeException('You need to enter "y" to continue or "n" to abort.');
+                    }
+
+                    return 'y' === $value;
+                });
+
+                if (!$answer) {
+                    $io->warning('You have aborted the command');
+
+                    return self::SUCCESS;
+                }
+            } else {
+                $io->writeln('The command will wait for 5 seconds before starting');
+                $progressBar = $io->createProgressBar(5);
+                $progressBar->start();
+                for ($i = 0; $i < 5; ++$i) {
+                    $progressBar->advance();
+                    \sleep(1);
+                }
+                $progressBar->finish();
+
+                $io->newLine();
+                $io->newLine();
+                $io->newLine();
+            }
+        }
+
+        $io->section('Initiating cleanup process ...');
+        $io->writeln('Project directory: ' . $this->projectDirectory);
+        $io->writeln('Dry-run: ' . ($input->getOption('dry-run') ? 'enabled' : 'disabled'));
+
+        $debug = $input->getOption('debug');
+        $io->writeln('Debug: ' . ($debug ? 'enabled' : 'disabled'));
+        $this->logger = function (string $message) {
+            // do not print anything
+        };
+
+        if ($input->getOption('debug')) {
+            $debugFile = $input->getOption('debug-file');
+            $io->writeln('Debug file: ' . $debugFile);
+
+            $this->logger = function (string $message) use ($debugFile) {
+                \file_put_contents($debugFile, $message . \PHP_EOL, \FILE_APPEND);
+            };
+        }
+
+        $io->newLine();
+        $io->newLine();
+
         $queryManager = $this->session->getWorkspace()->getQueryManager();
         $rows = $queryManager->createQuery('SELECT * FROM [nt:unstructured]', 'JCR-SQL2')->execute();
 
+        $stats = [
+            'nodes' => 0,
+            'properties' => 0,
+            'removedProperties' => 0,
+        ];
+
+        $io->section('Running cleanup process ...');
+        $progressBar = $io->createProgressBar();
+        $progressBar->setFormat("Nodes: %nodes%\nProperties: %properties%\nRemoved properties: %removedProperties%\n\n");
+
+        $progressBar->setMessage((string) $stats['nodes'], 'nodes');
+        $progressBar->setMessage((string) $stats['properties'], 'properties');
+        $progressBar->setMessage((string) $stats['removedProperties'], 'removedProperties');
+
+        $progressBar->start();
+
         foreach ($rows->getNodes() as $node) {
+            ++$stats['nodes'];
+
             foreach ($this->getLocales($node) as $locale) {
                 $document = $this->documentManager->find($node->getIdentifier(), $locale);
 
@@ -56,24 +162,60 @@ class PHPCRCleanupCommand extends Command
                 $this->documentManager->clear();
 
                 $writtenProperties = $cleanupNode->getWrittenPropertyKeys();
-                $this->cleanupNode($node, $locale, $writtenProperties);
+                foreach ($this->cleanupNode($node, $locale, $writtenProperties, $input->getOption('dry-run')) as $result) {
+                    ++$stats['properties'];
+                    $stats['removedProperties'] += $result ? 1 : 0;
+                }
 
-                $x = 0;
+                $this->session->save();
+                $this->documentManager->clear();
             }
+
+            $progressBar->setMessage((string) $stats['nodes'], 'nodes');
+            $progressBar->setMessage((string) $stats['properties'], 'properties');
+            $progressBar->setMessage((string) $stats['removedProperties'], 'removedProperties');
+            $progressBar->advance();
         }
+
+        $progressBar->finish();
+        $io->success('Cleanup process finished');
+
+        return self::SUCCESS;
     }
 
-    private function cleanupNode(NodeInterface $node, string $locale, array $writtenProperties)
+    private function cleanupNode(NodeInterface $node, string $locale, array $writtenProperties, bool $dryRun): \Generator
     {
+        \call_user_func($this->logger, \sprintf('# Cleaning up node "%s" for locale "%s"' . \PHP_EOL, $node->getPath(), $locale));
+
+        $whiteList = \array_map(fn ($property) => $this->namespaceRegistry->getPrefix('system_localized') . ':' . $locale . '-' . $property, self::WHITELIST);
+        \call_user_func($this->logger, \sprintf("Whitelisted:\n* %s\n", \implode("\n* ", $whiteList)));
+        \call_user_func($this->logger, \sprintf("Written:\n* %s\n", \implode("\n* ", $writtenProperties)));
+
+        $removedProperties = [];
         foreach ($node->getProperties() as $property) {
             if (!\str_starts_with($property->getName(), 'i18n:' . $locale)) {
+                yield false;
+
                 continue;
             }
 
-            if (!\in_array($property->getName(), $writtenProperties, true)) {
-                echo('Removing property ' . $property->getName() . ' from node ' . $node->getPath() . PHP_EOL);
+            if (\in_array($property->getName(), $writtenProperties, true)
+                || \in_array($property->getName(), $whiteList, true)
+            ) {
+                yield false;
+
+                continue;
             }
+
+            $removedProperties[] = $property->getName();
+            if (!$dryRun) {
+                $property->remove();
+            }
+
+            yield true;
         }
+
+        \call_user_func($this->logger, \sprintf("Removed:\n* %s\n", \implode("\n* ", $removedProperties)));
     }
 
     private function getOptionsResolver(string $eventName): OptionsResolver

--- a/src/Command/PHPCRCleanupCommand.php
+++ b/src/Command/PHPCRCleanupCommand.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use PHPCR\NodeInterface;
+use PHPCR\SessionInterface;
+use Sulu\Component\DocumentManager\DocumentManagerInterface;
+use Sulu\Component\DocumentManager\Event;
+use Sulu\Component\DocumentManager\Events;
+use Sulu\Component\DocumentManager\NamespaceRegistry;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+#[AsCommand(
+    name: 'phpcr:cleanup',
+    description: 'Clean up the PHPCR repository',
+)]
+class PHPCRCleanupCommand extends Command
+{
+    /**
+     * @var array<string, OptionsResolver> Cached options resolver instances
+     */
+    private array $optionsResolvers = [];
+
+    public function __construct(
+        private SessionInterface $session,
+        private NamespaceRegistry $namespaceRegistry,
+        private EventDispatcherInterface $documentManagerEventDispatcher,
+        private DocumentManagerInterface $documentManager,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $queryManager = $this->session->getWorkspace()->getQueryManager();
+        $rows = $queryManager->createQuery('SELECT * FROM [nt:unstructured]', 'JCR-SQL2')->execute();
+
+        foreach ($rows->getNodes() as $node) {
+            foreach ($this->getLocales($node) as $locale) {
+                $document = $this->documentManager->find($node->getIdentifier(), $locale);
+
+                $options = $this->getOptionsResolver(Events::PERSIST)->resolve();
+
+                $cleanupNode = new CleanupNode(clone $node);
+
+                $event = new Event\PersistEvent($document, $locale, $options);
+                $event->setNode($cleanupNode);
+                $this->documentManagerEventDispatcher->dispatch($event, Events::PERSIST);
+                $this->documentManager->clear();
+
+                $writtenProperties = $cleanupNode->getWrittenPropertyKeys();
+                $this->cleanupNode($node, $locale, $writtenProperties);
+
+                $x = 0;
+            }
+        }
+    }
+
+    private function cleanupNode(NodeInterface $node, string $locale, array $writtenProperties)
+    {
+        foreach ($node->getProperties() as $property) {
+            if (!\str_starts_with($property->getName(), 'i18n:' . $locale)) {
+                continue;
+            }
+
+            if (!\in_array($property->getName(), $writtenProperties, true)) {
+                echo('Removing property ' . $property->getName() . ' from node ' . $node->getPath() . PHP_EOL);
+            }
+        }
+    }
+
+    private function getOptionsResolver(string $eventName): OptionsResolver
+    {
+        if (isset($this->optionsResolvers[$eventName])) {
+            return $this->optionsResolvers[$eventName];
+        }
+
+        $resolver = new OptionsResolver();
+        $resolver->setDefault('locale', null);
+
+        $event = new Event\ConfigureOptionsEvent($resolver);
+        $this->documentManagerEventDispatcher->dispatch($event, Events::CONFIGURE_OPTIONS);
+
+        $this->optionsResolvers[$eventName] = $resolver;
+
+        return $resolver;
+    }
+
+    private function getLocales(NodeInterface $node)
+    {
+        $locales = [];
+        $prefix = $this->namespaceRegistry->getPrefix('system_localized');
+
+        foreach ($node->getProperties() as $property) {
+            \preg_match(
+                \sprintf('/^%s:([a-zA-Z_]*?)-.*/', $prefix),
+                $property->getName(),
+                $matches,
+            );
+
+            if ($matches) {
+                $locales[$matches[1]] = $matches[1];
+            }
+        }
+
+        return \array_values(\array_unique($locales));
+    }
+}


### PR DESCRIPTION
TODO:

- [x] Use also publish event and the live session to cleanup the live node
- [ ] Test with different languages, blocks and image_maps
- [ ] Test with audience-targeting
- [x] Refactor to use StreamOutput with a file handle
- [x] Guard the node with:
  * Check the alias and if the structure manager has metadata for the alias (see https://github.com/mamazu/sulu/pull/2/files#diff-fd6471db309389445b7798ca7915fa5cd47010b1d91336a145f60e36276abb93R77-R80)
  * Check if language has a template 
  * Ignore nodes which could not be persisted (and or published)
- [ ] Add summary of the cleanup (stats and ignored nodes) to the debug-file at the top
- [ ] Feedback from @mamazu
- [x] Move the code to sulu/sulu https://github.com/sulu/sulu/pull/7291